### PR TITLE
Fixed Perl 5.14 problem.

### DIFF
--- a/mongo_support.c
+++ b/mongo_support.c
@@ -429,7 +429,11 @@ elem_to_sv (int type, buffer *buf)
     while(*(buf->pos) != 0) {
       switch(*(buf->pos)) {
       case 'l':
+#if PERL_REVISION==5 && PERL_VERSION<=12
         flags |= PMf_LOCALE;
+#else
+        set_regex_charset(&flags, REGEX_LOCALE_CHARSET);
+#endif
         break;
       case 'm':
         flags |= PMf_MULTILINE;


### PR DESCRIPTION
Patch from mongo-perl-driver (https://github.com/mongodb/mongo-perl-driver/commit/defd2c168a8439ba2c279770f595d7bd56081e6e). Tested on Fedora 16.
